### PR TITLE
Update jquery.collagePlus.js

### DIFF
--- a/jquery.collagePlus.js
+++ b/jquery.collagePlus.js
@@ -315,7 +315,7 @@
                  */
 
                 $img
-                    .load(function(target) {
+                    .one('load', function (target) {
                     return function(){
                         if( settings.effect == 'default'){
                             target.animate({opacity: '1'},{duration: settings.fadeSpeed});
@@ -325,7 +325,10 @@
                             } else {
                                 var sequence = (i <= 9  ? i+1 : 10);
                             }
-
+                            /* Remove old classes with the "effect-" name */
+                            target.removeClass(function (index, css) {
+                                return (css.match(/\beffect-\S+/g) || []).join(' ');
+                            });
                             target.addClass(settings.effect);
                             target.addClass("effect-duration-" + sequence);
                         }


### PR DESCRIPTION
Added support for running the plug-in multiple times on the same images.
(When shuffling images with different effects applied)

The .load method triggered multiple times, which caused the images to get too many classes applied.  

Old classes starting with effect-\* are now removed.
