### PR TITLE
Some rows don't stretching well regarding to parent's width size

### DIFF
--- a/jquery.collagePlus.js
+++ b/jquery.collagePlus.js
@@ -249,8 +249,6 @@
                     }
                 }
 
-                fw--;
-
                 /*
                  *
                  * We'll be doing a few things to the image so here we cache the image selector


### PR DESCRIPTION
Hi Ed,
after an exhaustive set of test cases with images retrieved with Flickr API, i figured out a weird behavior regarding how each row being stretched well enough in order to get the full available width, in case the row's width is less than the parent's album width. So in many test cases i ended up with the following miss-layout issues,
- some last images don't stretching well enough ending with a larger right padding space than others,
- the right padding of the album seems to be slightly larger than the left one (use an outer border to see),

So i've been digging into your code today and i found a statement in which you're decreasing the calculate width fw by one, just after the part in which you're stretching the width well enough to get the parent's width. So far i tested and it seems to be working flawlessly now.

You've done a great work, so many thanks.
